### PR TITLE
Added timezone to getCurrentTime method

### DIFF
--- a/lib/utils/DateUtils.d.ts
+++ b/lib/utils/DateUtils.d.ts
@@ -1,3 +1,3 @@
 export declare class DateUtils {
-    static getDateRange(difference: number): any;
+    static getDateRange(difference: number, timezone?: string): any;
 }

--- a/lib/utils/DateUtils.js
+++ b/lib/utils/DateUtils.js
@@ -5,8 +5,15 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.DateUtils = void 0;
 const dayjs_1 = __importDefault(require("dayjs"));
+const utc_1 = __importDefault(require("dayjs/plugin/utc"));
+const timezone_1 = __importDefault(require("dayjs/plugin/timezone"));
+dayjs_1.default.extend(utc_1.default);
+dayjs_1.default.extend(timezone_1.default);
 class DateUtils {
-    static getDateRange(difference) {
+    static getDateRange(difference, timezone) {
+        if (timezone) {
+            dayjs_1.default.tz.setDefault(timezone); // America/Argentina/Buenos_Aires
+        }
         let now = (0, dayjs_1.default)();
         const startDate = now.subtract(difference, 'day').startOf('day');
         const endDate = now.subtract(difference, 'day').endOf('day');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digiventures.stack/utils-helper",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "publishConfig": {
     "access": "public"
   },

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -1,10 +1,34 @@
 import dayjs from 'dayjs';
 
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
 export class DateUtils {
 
-  static getDateRange(difference: number): any {
+  static getDateRange(difference: number, timezone?: string): any {
+    if (timezone) {
+      dayjs.tz.setDefault(timezone);
+    }
+
     let now = dayjs();
 
+    const startDate = now.subtract(difference, 'day').startOf('day');
+    const endDate = now.subtract(difference, 'day').endOf('day');
+
+    return {
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString(),
+    };
+  }
+
+  static getDateRangeAsGMT(difference: number, timezone?: string): any {
+    const _timezone: string = timezone ? timezone : 'America/Argentina/Buenos_Aires'
+
+
+    let now = dayjs();
     const startDate = now.subtract(difference, 'day').startOf('day');
     const endDate = now.subtract(difference, 'day').endOf('day');
 

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -10,25 +10,11 @@ export class DateUtils {
 
   static getDateRange(difference: number, timezone?: string): any {
     if (timezone) {
-      dayjs.tz.setDefault(timezone);
+      dayjs.tz.setDefault(timezone); // America/Argentina/Buenos_Aires
     }
 
     let now = dayjs();
 
-    const startDate = now.subtract(difference, 'day').startOf('day');
-    const endDate = now.subtract(difference, 'day').endOf('day');
-
-    return {
-      startDate: startDate.toISOString(),
-      endDate: endDate.toISOString(),
-    };
-  }
-
-  static getDateRangeAsGMT(difference: number, timezone?: string): any {
-    const _timezone: string = timezone ? timezone : 'America/Argentina/Buenos_Aires'
-
-
-    let now = dayjs();
     const startDate = now.subtract(difference, 'day').startOf('day');
     const endDate = now.subtract(difference, 'day').endOf('day');
 


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the `getDateRange` function in `DateUtils.ts` to accept an optional `timezone` parameter. This allows users to get date ranges based on specific timezones.
- New Feature: Introduced a new function `getDateRangeAsGMT` in `DateUtils.ts` that returns the date range in GMT timezone, providing more flexibility for global users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->