### PR TITLE
fix/OB-3238: add regex to match urls with the bucket name in the subdomain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@digiventures.stack/utils-helper",
-  "version": "1.1.41",
+  "version": "2.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digiventures.stack/utils-helper",
-      "version": "1.1.41",
+      "version": "2.0.7",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.445.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.425.0",
         "@aws-sdk/client-s3": "^3.614.0",
-        "@aws-sdk/client-secrets-manager": "^3.614.0",
+        "@aws-sdk/client-secrets-manager": "^3.620.1",
         "@aws-sdk/client-sqs": "^3.614.0",
         "@aws-sdk/client-sts": "^3.614.0",
         "@elastic/elasticsearch": "7.9.0",
@@ -2224,46 +2224,46 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.614.0.tgz",
-      "integrity": "sha512-gxCYaRYF78R5xBxXoKdF+xiWiElIJqOTSNxjt28ch+GEn9TNAYwpQcTxejBZ5VxeDwbmBjRaB9Vpx9FPeImTMw==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.620.1.tgz",
+      "integrity": "sha512-wLZHjLJsJGYFw9Xx4Xf1lG6YEgZvwyoe+yJz4m0wsYhoT7bkoXk8j3qKrkK9qwdyEjPLx/e4xD3ouOjhk41gYQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.614.0",
-        "@aws-sdk/client-sts": "3.614.0",
-        "@aws-sdk/core": "3.614.0",
-        "@aws-sdk/credential-provider-node": "3.614.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.620.1",
+        "@aws-sdk/client-sts": "3.620.1",
+        "@aws-sdk/core": "3.620.1",
+        "@aws-sdk/credential-provider-node": "3.620.1",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.614.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.6",
-        "@smithy/fetch-http-handler": "^3.2.1",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.9",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.2",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.9",
-        "@smithy/util-defaults-mode-node": "^3.0.9",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
         "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -2390,17 +2390,323 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/core": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.614.0.tgz",
-      "integrity": "sha512-BUuS5/1YkgmKc4J0bg83XEtMyDHVyqG2QDzfmhYe8gbOIZabUl1FlrFVwhCAthtrrI6MPGTQcERB4BtJKUSplw==",
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sso": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.620.1.tgz",
+      "integrity": "sha512-4Ox0BSs+atrAhLvjNHN2uiYvSTdpMv//IS4l4XRoQG0cJKIPLs3OU3PL5H0X1NfZehz9/8FTWl5Lv81uw4j1eA==",
       "dependencies": {
-        "@smithy/core": "^2.2.6",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/signature-v4": "^3.1.2",
-        "@smithy/smithy-client": "^3.1.7",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.620.1",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.620.1.tgz",
+      "integrity": "sha512-gm69ttbkr7Kbg/Zzr3SczyLWkLgmK3bEZtkvbM/40ZW5ItYhDzJE48Ovs2lyA64h2YsOftDqqwcbJirAAdTgSg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.620.1",
+        "@aws-sdk/credential-provider-node": "3.620.1",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.620.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sts": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.620.1.tgz",
+      "integrity": "sha512-d+ECGFDg0IsDdmfKU2O0VeMYKZcmbfBaA9HkZnZ39wu1BlXGI73xJe8cfmzbobvu+Ly+bAfHdLCpgIY+pD4D7g==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.620.1",
+        "@aws-sdk/core": "3.620.1",
+        "@aws-sdk/credential-provider-node": "3.620.1",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/core": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.620.1.tgz",
+      "integrity": "sha512-6Ejce93dDlDnovl6oYtxj3I/SJMOQoFdmmtM4+4W/cgMWH+l00T5aszVxDLjjPfu3Ryt7dNhrXaYeK2Ue1ZBmg==",
+      "dependencies": {
+        "@smithy/core": "^2.3.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
         "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.620.0.tgz",
+      "integrity": "sha512-BI2BdrSKDmB/2ouB/NJR0PT0x/+5fmoF6XOE78hFBb4F5w/yynGgcJY936dF+oREfpME6ehjB2b0okGg78Scpw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.620.1.tgz",
+      "integrity": "sha512-m9jwigMPRlRRhoPxCQZMOwQUd6imEJbksF6tSMYNae76DIvrCi4z2Jhp6RJ9Mij8cnewUZCAmvu2FlK9+n9M7A==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.620.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.620.1",
+        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.620.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.620.1.tgz",
+      "integrity": "sha512-KaprIJW2azM+oTIHi7S1ayJ3oQqoFwpMBWFpZM1nvSzaPucrZIUmX2m4uVrMM4LfXsfUsgMkrme2rBI1fGAjCg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.620.0",
+        "@aws-sdk/credential-provider-ini": "3.620.1",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.620.1",
+        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.620.1.tgz",
+      "integrity": "sha512-cFU8e6ctdkWR8BRCnHFzs37N+ilbHf1OT2EeMjt1ZDE9FgTD5L5BTgVWDxnPmyQnEoBs1p4PyNPHkpHY5EmswQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.620.1",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.620.0.tgz",
+      "integrity": "sha512-bvS6etn+KsuL32ubY5D3xNof1qkenpbJXf/ugGXbg0n98DvDFQ/F+SMLxHgbnER5dsKYchNnhmtI6/FC3HFu/A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2451,9 +2757,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/credential-provider-imds": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.4.tgz",
-      "integrity": "sha512-NKyH01m97Xa5xf3pB2QOF3lnuE8RIK0hTVNU5zvZAwZU8uspYO4DHQVlK+Y5gwSrujTfHvbfd1D9UFJAc0iYKQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
@@ -2466,11 +2772,11 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/fetch-http-handler": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.2.tgz",
-      "integrity": "sha512-3LaWlBZObyGrOOd7e5MlacnAKEwFBmAeiW/TOj2eR9475Vnq30uS2510+tnKbxrGjROfNdOhQqGo5j3sqLT6bA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/querystring-builder": "^3.0.3",
         "@smithy/types": "^3.3.0",
         "@smithy/util-base64": "^3.0.0",
@@ -2512,11 +2818,11 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.4.tgz",
-      "integrity": "sha512-wySGje/KfhsnF8YSh9hP16pZcl3C+X6zRsvSfItQGvCyte92LliilU3SD0nR7kTlxnAJwxY8vE/k4Eoezj847Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2525,9 +2831,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/middleware-endpoint": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
-      "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
       "dependencies": {
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
@@ -2542,14 +2848,14 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/middleware-retry": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.11.tgz",
-      "integrity": "sha512-/TIRWmhwMpv99JCGuMhJPnH7ggk/Lah7s/uNDyr7faF02BxNsyD/fz9Tw7pgCf9tYOKgjimm2Qml1Aq1pbkt6g==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.13.tgz",
+      "integrity": "sha512-zvCLfaRYCaUmjbF2yxShGZdolSHft7NNCTA28HVN9hKcEbOH+g5irr1X9s+in8EpambclGnevZY4A3lYpvDCFw==",
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/smithy-client": "^3.1.11",
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -2599,12 +2905,12 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/node-http-handler": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.3.tgz",
-      "integrity": "sha512-UiKZm8KHb/JeOPzHZtRUfyaRDO1KPKPpsd7iplhiwVGOeVdkiVJ5bVe7+NhWREMOKomrDIDdSZyglvMothLg0Q==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
       "dependencies": {
         "@smithy/abort-controller": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/querystring-builder": "^3.0.3",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -2626,9 +2932,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/protocol-http": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
-      "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
       "dependencies": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -2686,11 +2992,12 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/signature-v4": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
-      "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+      "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "@smithy/util-hex-encoding": "^3.0.0",
         "@smithy/util-middleware": "^3.0.3",
@@ -2703,15 +3010,15 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/smithy-client": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.9.tgz",
-      "integrity": "sha512-My2RaInZ4gSwJUPMaiLR/Nk82+c4LlvqpXA+n7lonGYgCZq23Tg+/xFhgmiejJ6XPElYJysTPyV90vKyp17+1g==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.11.tgz",
+      "integrity": "sha512-l0BpyYkciNyMaS+PnFFz4aO5sBcXvGLoJd7mX9xrMBIm2nIQBVvYgp2ZpPDMzwjKCavsXu06iuCm0F6ZJZc6yQ==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.1.1",
+        "@smithy/util-stream": "^3.1.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2795,12 +3102,12 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.11.tgz",
-      "integrity": "sha512-O3s9DGb3bmRvEKmT8RwvSWK4A9r6svfd+MnJB+UMi9ZcCkAnoRtliulOnGF0qCMkKF9mwk2tkopBBstalPY/vg==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.13.tgz",
+      "integrity": "sha512-ZIRSUsnnMRStOP6OKtW+gCSiVFkwnfQF2xtf32QKAbHR6ACjhbAybDvry+3L5qQYdh3H6+7yD/AiUE45n8mTTw==",
       "dependencies": {
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/smithy-client": "^3.1.11",
         "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -2810,15 +3117,15 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.11.tgz",
-      "integrity": "sha512-qd4a9qtyOa/WY14aHHOkMafhh9z8D2QTwlcBoXMTPnEwtcY+xpe1JyFm9vya7VsB8hHsfn3XodEtwqREiu4ygQ==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.13.tgz",
+      "integrity": "sha512-voUa8TFJGfD+U12tlNNLCDlXibt9vRdNzRX45Onk/WxZe7TS+hTOZouEZRa7oARGicdgeXvt1A0W45qLGYdy+g==",
       "dependencies": {
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/node-config-provider": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/smithy-client": "^3.1.11",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2876,12 +3183,12 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/util-stream": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.1.tgz",
-      "integrity": "sha512-EhRnVvl3AhoHAT2rGQ5o+oSDRM/BUSMPLZZdRJZLcNVUsFAjOs4vHaPdNQivTSzRcFxf5DA4gtO46WWU2zimaw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.2.2",
-        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
@@ -11247,15 +11554,15 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/core": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.8.tgz",
-      "integrity": "sha512-1Y0XX0Ucyg0LWTfTVLWpmvSRtFRniykUl3dQ0os1sTd03mKDudR6mVyX+2ak1phwPXx2aEWMAAdW52JNi0mc3A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.3.1.tgz",
+      "integrity": "sha512-BC7VMXx/1BCmRPCVzzn4HGWAtsrb7/0758EtwOGFJQrlSwJBEjCcDLNZLFoL/68JexYa2s+KmgL/UfmXdG6v1w==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.11",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.13",
         "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.11",
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
         "tslib": "^2.6.2"
@@ -11277,11 +11584,11 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/fetch-http-handler": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.2.tgz",
-      "integrity": "sha512-3LaWlBZObyGrOOd7e5MlacnAKEwFBmAeiW/TOj2eR9475Vnq30uS2510+tnKbxrGjROfNdOhQqGo5j3sqLT6bA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/querystring-builder": "^3.0.3",
         "@smithy/types": "^3.3.0",
         "@smithy/util-base64": "^3.0.0",
@@ -11300,9 +11607,9 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/middleware-endpoint": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
-      "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
       "dependencies": {
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
@@ -11317,14 +11624,14 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/middleware-retry": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.11.tgz",
-      "integrity": "sha512-/TIRWmhwMpv99JCGuMhJPnH7ggk/Lah7s/uNDyr7faF02BxNsyD/fz9Tw7pgCf9tYOKgjimm2Qml1Aq1pbkt6g==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.13.tgz",
+      "integrity": "sha512-zvCLfaRYCaUmjbF2yxShGZdolSHft7NNCTA28HVN9hKcEbOH+g5irr1X9s+in8EpambclGnevZY4A3lYpvDCFw==",
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/smithy-client": "^3.1.11",
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -11374,12 +11681,12 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/node-http-handler": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.3.tgz",
-      "integrity": "sha512-UiKZm8KHb/JeOPzHZtRUfyaRDO1KPKPpsd7iplhiwVGOeVdkiVJ5bVe7+NhWREMOKomrDIDdSZyglvMothLg0Q==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
       "dependencies": {
         "@smithy/abort-controller": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/querystring-builder": "^3.0.3",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -11401,9 +11708,9 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/protocol-http": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
-      "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
       "dependencies": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -11461,15 +11768,15 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/smithy-client": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.9.tgz",
-      "integrity": "sha512-My2RaInZ4gSwJUPMaiLR/Nk82+c4LlvqpXA+n7lonGYgCZq23Tg+/xFhgmiejJ6XPElYJysTPyV90vKyp17+1g==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.11.tgz",
+      "integrity": "sha512-l0BpyYkciNyMaS+PnFFz4aO5sBcXvGLoJd7mX9xrMBIm2nIQBVvYgp2ZpPDMzwjKCavsXu06iuCm0F6ZJZc6yQ==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.1.1",
+        "@smithy/util-stream": "^3.1.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11559,12 +11866,12 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/util-stream": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.1.tgz",
-      "integrity": "sha512-EhRnVvl3AhoHAT2rGQ5o+oSDRM/BUSMPLZZdRJZLcNVUsFAjOs4vHaPdNQivTSzRcFxf5DA4gtO46WWU2zimaw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.2.2",
-        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
@@ -21779,46 +22086,46 @@
       }
     },
     "@aws-sdk/client-secrets-manager": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.614.0.tgz",
-      "integrity": "sha512-gxCYaRYF78R5xBxXoKdF+xiWiElIJqOTSNxjt28ch+GEn9TNAYwpQcTxejBZ5VxeDwbmBjRaB9Vpx9FPeImTMw==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.620.1.tgz",
+      "integrity": "sha512-wLZHjLJsJGYFw9Xx4Xf1lG6YEgZvwyoe+yJz4m0wsYhoT7bkoXk8j3qKrkK9qwdyEjPLx/e4xD3ouOjhk41gYQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.614.0",
-        "@aws-sdk/client-sts": "3.614.0",
-        "@aws-sdk/core": "3.614.0",
-        "@aws-sdk/credential-provider-node": "3.614.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.620.1",
+        "@aws-sdk/client-sts": "3.620.1",
+        "@aws-sdk/core": "3.620.1",
+        "@aws-sdk/credential-provider-node": "3.620.1",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.614.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
         "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-endpoints": "3.614.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
         "@aws-sdk/util-user-agent-node": "3.614.0",
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.6",
-        "@smithy/fetch-http-handler": "^3.2.1",
+        "@smithy/core": "^2.3.0",
+        "@smithy/fetch-http-handler": "^3.2.3",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.9",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.12",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.2",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.10",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.9",
-        "@smithy/util-defaults-mode-node": "^3.0.9",
+        "@smithy/util-defaults-mode-browser": "^3.0.12",
+        "@smithy/util-defaults-mode-node": "^3.0.12",
         "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -21925,17 +22232,281 @@
             }
           }
         },
-        "@aws-sdk/core": {
-          "version": "3.614.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.614.0.tgz",
-          "integrity": "sha512-BUuS5/1YkgmKc4J0bg83XEtMyDHVyqG2QDzfmhYe8gbOIZabUl1FlrFVwhCAthtrrI6MPGTQcERB4BtJKUSplw==",
+        "@aws-sdk/client-sso": {
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.620.1.tgz",
+          "integrity": "sha512-4Ox0BSs+atrAhLvjNHN2uiYvSTdpMv//IS4l4XRoQG0cJKIPLs3OU3PL5H0X1NfZehz9/8FTWl5Lv81uw4j1eA==",
           "requires": {
-            "@smithy/core": "^2.2.6",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/signature-v4": "^3.1.2",
-            "@smithy/smithy-client": "^3.1.7",
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.620.1",
+            "@aws-sdk/middleware-host-header": "3.620.0",
+            "@aws-sdk/middleware-logger": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.620.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
+            "@aws-sdk/types": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.614.0",
+            "@aws-sdk/util-user-agent-browser": "3.609.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.0",
+            "@smithy/fetch-http-handler": "^3.2.3",
+            "@smithy/hash-node": "^3.0.3",
+            "@smithy/invalid-dependency": "^3.0.3",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.12",
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.10",
             "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.12",
+            "@smithy/util-defaults-mode-node": "^3.0.12",
+            "@smithy/util-endpoints": "^2.0.5",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-retry": "^3.0.3",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.620.1.tgz",
+          "integrity": "sha512-gm69ttbkr7Kbg/Zzr3SczyLWkLgmK3bEZtkvbM/40ZW5ItYhDzJE48Ovs2lyA64h2YsOftDqqwcbJirAAdTgSg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.620.1",
+            "@aws-sdk/credential-provider-node": "3.620.1",
+            "@aws-sdk/middleware-host-header": "3.620.0",
+            "@aws-sdk/middleware-logger": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.620.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
+            "@aws-sdk/types": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.614.0",
+            "@aws-sdk/util-user-agent-browser": "3.609.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.0",
+            "@smithy/fetch-http-handler": "^3.2.3",
+            "@smithy/hash-node": "^3.0.3",
+            "@smithy/invalid-dependency": "^3.0.3",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.12",
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.10",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.12",
+            "@smithy/util-defaults-mode-node": "^3.0.12",
+            "@smithy/util-endpoints": "^2.0.5",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-retry": "^3.0.3",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.620.1.tgz",
+          "integrity": "sha512-d+ECGFDg0IsDdmfKU2O0VeMYKZcmbfBaA9HkZnZ39wu1BlXGI73xJe8cfmzbobvu+Ly+bAfHdLCpgIY+pD4D7g==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/client-sso-oidc": "3.620.1",
+            "@aws-sdk/core": "3.620.1",
+            "@aws-sdk/credential-provider-node": "3.620.1",
+            "@aws-sdk/middleware-host-header": "3.620.0",
+            "@aws-sdk/middleware-logger": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.620.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
+            "@aws-sdk/types": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.614.0",
+            "@aws-sdk/util-user-agent-browser": "3.609.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.0",
+            "@smithy/fetch-http-handler": "^3.2.3",
+            "@smithy/hash-node": "^3.0.3",
+            "@smithy/invalid-dependency": "^3.0.3",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.12",
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.10",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-body-length-browser": "^3.0.0",
+            "@smithy/util-body-length-node": "^3.0.0",
+            "@smithy/util-defaults-mode-browser": "^3.0.12",
+            "@smithy/util-defaults-mode-node": "^3.0.12",
+            "@smithy/util-endpoints": "^2.0.5",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-retry": "^3.0.3",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/core": {
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.620.1.tgz",
+          "integrity": "sha512-6Ejce93dDlDnovl6oYtxj3I/SJMOQoFdmmtM4+4W/cgMWH+l00T5aszVxDLjjPfu3Ryt7dNhrXaYeK2Ue1ZBmg==",
+          "requires": {
+            "@smithy/core": "^2.3.0",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/signature-v4": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.10",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-middleware": "^3.0.3",
             "fast-xml-parser": "4.2.5",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+          "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
+          "requires": {
+            "@aws-sdk/types": "3.609.0",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-http": {
+          "version": "3.620.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.620.0.tgz",
+          "integrity": "sha512-BI2BdrSKDmB/2ouB/NJR0PT0x/+5fmoF6XOE78hFBb4F5w/yynGgcJY936dF+oREfpME6ehjB2b0okGg78Scpw==",
+          "requires": {
+            "@aws-sdk/types": "3.609.0",
+            "@smithy/fetch-http-handler": "^3.2.3",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.10",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-stream": "^3.1.2",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.620.1.tgz",
+          "integrity": "sha512-m9jwigMPRlRRhoPxCQZMOwQUd6imEJbksF6tSMYNae76DIvrCi4z2Jhp6RJ9Mij8cnewUZCAmvu2FlK9+n9M7A==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.620.1",
+            "@aws-sdk/credential-provider-http": "3.620.0",
+            "@aws-sdk/credential-provider-process": "3.620.1",
+            "@aws-sdk/credential-provider-sso": "3.620.1",
+            "@aws-sdk/credential-provider-web-identity": "3.609.0",
+            "@aws-sdk/types": "3.609.0",
+            "@smithy/credential-provider-imds": "^3.2.0",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.620.1.tgz",
+          "integrity": "sha512-KaprIJW2azM+oTIHi7S1ayJ3oQqoFwpMBWFpZM1nvSzaPucrZIUmX2m4uVrMM4LfXsfUsgMkrme2rBI1fGAjCg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.620.1",
+            "@aws-sdk/credential-provider-http": "3.620.0",
+            "@aws-sdk/credential-provider-ini": "3.620.1",
+            "@aws-sdk/credential-provider-process": "3.620.1",
+            "@aws-sdk/credential-provider-sso": "3.620.1",
+            "@aws-sdk/credential-provider-web-identity": "3.609.0",
+            "@aws-sdk/types": "3.609.0",
+            "@smithy/credential-provider-imds": "^3.2.0",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+          "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
+          "requires": {
+            "@aws-sdk/types": "3.609.0",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.620.1.tgz",
+          "integrity": "sha512-cFU8e6ctdkWR8BRCnHFzs37N+ilbHf1OT2EeMjt1ZDE9FgTD5L5BTgVWDxnPmyQnEoBs1p4PyNPHkpHY5EmswQ==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.620.1",
+            "@aws-sdk/token-providers": "3.614.0",
+            "@aws-sdk/types": "3.609.0",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.620.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+          "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
+          "requires": {
+            "@aws-sdk/types": "3.609.0",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.620.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+          "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
+          "requires": {
+            "@aws-sdk/types": "3.609.0",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.620.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.620.0.tgz",
+          "integrity": "sha512-bvS6etn+KsuL32ubY5D3xNof1qkenpbJXf/ugGXbg0n98DvDFQ/F+SMLxHgbnER5dsKYchNnhmtI6/FC3HFu/A==",
+          "requires": {
+            "@aws-sdk/types": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.614.0",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -21974,9 +22545,9 @@
           }
         },
         "@smithy/credential-provider-imds": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.4.tgz",
-          "integrity": "sha512-NKyH01m97Xa5xf3pB2QOF3lnuE8RIK0hTVNU5zvZAwZU8uspYO4DHQVlK+Y5gwSrujTfHvbfd1D9UFJAc0iYKQ==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+          "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
           "requires": {
             "@smithy/node-config-provider": "^3.1.4",
             "@smithy/property-provider": "^3.1.3",
@@ -21986,11 +22557,11 @@
           }
         },
         "@smithy/fetch-http-handler": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.2.tgz",
-          "integrity": "sha512-3LaWlBZObyGrOOd7e5MlacnAKEwFBmAeiW/TOj2eR9475Vnq30uS2510+tnKbxrGjROfNdOhQqGo5j3sqLT6bA==",
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+          "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
           "requires": {
-            "@smithy/protocol-http": "^4.0.4",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/querystring-builder": "^3.0.3",
             "@smithy/types": "^3.3.0",
             "@smithy/util-base64": "^3.0.0",
@@ -22026,19 +22597,19 @@
           }
         },
         "@smithy/middleware-content-length": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.4.tgz",
-          "integrity": "sha512-wySGje/KfhsnF8YSh9hP16pZcl3C+X6zRsvSfItQGvCyte92LliilU3SD0nR7kTlxnAJwxY8vE/k4Eoezj847Q==",
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+          "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
           "requires": {
-            "@smithy/protocol-http": "^4.0.4",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/middleware-endpoint": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
-          "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
           "requires": {
             "@smithy/middleware-serde": "^3.0.3",
             "@smithy/node-config-provider": "^3.1.4",
@@ -22050,14 +22621,14 @@
           }
         },
         "@smithy/middleware-retry": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.11.tgz",
-          "integrity": "sha512-/TIRWmhwMpv99JCGuMhJPnH7ggk/Lah7s/uNDyr7faF02BxNsyD/fz9Tw7pgCf9tYOKgjimm2Qml1Aq1pbkt6g==",
+          "version": "3.0.13",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.13.tgz",
+          "integrity": "sha512-zvCLfaRYCaUmjbF2yxShGZdolSHft7NNCTA28HVN9hKcEbOH+g5irr1X9s+in8EpambclGnevZY4A3lYpvDCFw==",
           "requires": {
             "@smithy/node-config-provider": "^3.1.4",
-            "@smithy/protocol-http": "^4.0.4",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/smithy-client": "^3.1.9",
+            "@smithy/smithy-client": "^3.1.11",
             "@smithy/types": "^3.3.0",
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-retry": "^3.0.3",
@@ -22095,12 +22666,12 @@
           }
         },
         "@smithy/node-http-handler": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.3.tgz",
-          "integrity": "sha512-UiKZm8KHb/JeOPzHZtRUfyaRDO1KPKPpsd7iplhiwVGOeVdkiVJ5bVe7+NhWREMOKomrDIDdSZyglvMothLg0Q==",
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+          "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
           "requires": {
             "@smithy/abort-controller": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.4",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/querystring-builder": "^3.0.3",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
@@ -22116,9 +22687,9 @@
           }
         },
         "@smithy/protocol-http": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
-          "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
           "requires": {
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
@@ -22161,11 +22732,12 @@
           }
         },
         "@smithy/signature-v4": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
-          "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+          "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
             "@smithy/util-hex-encoding": "^3.0.0",
             "@smithy/util-middleware": "^3.0.3",
@@ -22175,15 +22747,15 @@
           }
         },
         "@smithy/smithy-client": {
-          "version": "3.1.9",
-          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.9.tgz",
-          "integrity": "sha512-My2RaInZ4gSwJUPMaiLR/Nk82+c4LlvqpXA+n7lonGYgCZq23Tg+/xFhgmiejJ6XPElYJysTPyV90vKyp17+1g==",
+          "version": "3.1.11",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.11.tgz",
+          "integrity": "sha512-l0BpyYkciNyMaS+PnFFz4aO5sBcXvGLoJd7mX9xrMBIm2nIQBVvYgp2ZpPDMzwjKCavsXu06iuCm0F6ZJZc6yQ==",
           "requires": {
-            "@smithy/middleware-endpoint": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
             "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/protocol-http": "^4.0.4",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
-            "@smithy/util-stream": "^3.1.1",
+            "@smithy/util-stream": "^3.1.3",
             "tslib": "^2.6.2"
           }
         },
@@ -22249,27 +22821,27 @@
           }
         },
         "@smithy/util-defaults-mode-browser": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.11.tgz",
-          "integrity": "sha512-O3s9DGb3bmRvEKmT8RwvSWK4A9r6svfd+MnJB+UMi9ZcCkAnoRtliulOnGF0qCMkKF9mwk2tkopBBstalPY/vg==",
+          "version": "3.0.13",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.13.tgz",
+          "integrity": "sha512-ZIRSUsnnMRStOP6OKtW+gCSiVFkwnfQF2xtf32QKAbHR6ACjhbAybDvry+3L5qQYdh3H6+7yD/AiUE45n8mTTw==",
           "requires": {
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/smithy-client": "^3.1.9",
+            "@smithy/smithy-client": "^3.1.11",
             "@smithy/types": "^3.3.0",
             "bowser": "^2.11.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-defaults-mode-node": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.11.tgz",
-          "integrity": "sha512-qd4a9qtyOa/WY14aHHOkMafhh9z8D2QTwlcBoXMTPnEwtcY+xpe1JyFm9vya7VsB8hHsfn3XodEtwqREiu4ygQ==",
+          "version": "3.0.13",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.13.tgz",
+          "integrity": "sha512-voUa8TFJGfD+U12tlNNLCDlXibt9vRdNzRX45Onk/WxZe7TS+hTOZouEZRa7oARGicdgeXvt1A0W45qLGYdy+g==",
           "requires": {
             "@smithy/config-resolver": "^3.0.5",
-            "@smithy/credential-provider-imds": "^3.1.4",
+            "@smithy/credential-provider-imds": "^3.2.0",
             "@smithy/node-config-provider": "^3.1.4",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/smithy-client": "^3.1.9",
+            "@smithy/smithy-client": "^3.1.11",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
@@ -22312,12 +22884,12 @@
           }
         },
         "@smithy/util-stream": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.1.tgz",
-          "integrity": "sha512-EhRnVvl3AhoHAT2rGQ5o+oSDRM/BUSMPLZZdRJZLcNVUsFAjOs4vHaPdNQivTSzRcFxf5DA4gtO46WWU2zimaw==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+          "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
           "requires": {
-            "@smithy/fetch-http-handler": "^3.2.2",
-            "@smithy/node-http-handler": "^3.1.3",
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "@smithy/util-base64": "^3.0.0",
             "@smithy/util-buffer-from": "^3.0.0",
@@ -28899,15 +29471,15 @@
       }
     },
     "@smithy/core": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.8.tgz",
-      "integrity": "sha512-1Y0XX0Ucyg0LWTfTVLWpmvSRtFRniykUl3dQ0os1sTd03mKDudR6mVyX+2ak1phwPXx2aEWMAAdW52JNi0mc3A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.3.1.tgz",
+      "integrity": "sha512-BC7VMXx/1BCmRPCVzzn4HGWAtsrb7/0758EtwOGFJQrlSwJBEjCcDLNZLFoL/68JexYa2s+KmgL/UfmXdG6v1w==",
       "requires": {
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.11",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.13",
         "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.11",
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
         "tslib": "^2.6.2"
@@ -28923,11 +29495,11 @@
           }
         },
         "@smithy/fetch-http-handler": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.2.tgz",
-          "integrity": "sha512-3LaWlBZObyGrOOd7e5MlacnAKEwFBmAeiW/TOj2eR9475Vnq30uS2510+tnKbxrGjROfNdOhQqGo5j3sqLT6bA==",
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+          "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
           "requires": {
-            "@smithy/protocol-http": "^4.0.4",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/querystring-builder": "^3.0.3",
             "@smithy/types": "^3.3.0",
             "@smithy/util-base64": "^3.0.0",
@@ -28943,9 +29515,9 @@
           }
         },
         "@smithy/middleware-endpoint": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
-          "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
           "requires": {
             "@smithy/middleware-serde": "^3.0.3",
             "@smithy/node-config-provider": "^3.1.4",
@@ -28957,14 +29529,14 @@
           }
         },
         "@smithy/middleware-retry": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.11.tgz",
-          "integrity": "sha512-/TIRWmhwMpv99JCGuMhJPnH7ggk/Lah7s/uNDyr7faF02BxNsyD/fz9Tw7pgCf9tYOKgjimm2Qml1Aq1pbkt6g==",
+          "version": "3.0.13",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.13.tgz",
+          "integrity": "sha512-zvCLfaRYCaUmjbF2yxShGZdolSHft7NNCTA28HVN9hKcEbOH+g5irr1X9s+in8EpambclGnevZY4A3lYpvDCFw==",
           "requires": {
             "@smithy/node-config-provider": "^3.1.4",
-            "@smithy/protocol-http": "^4.0.4",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/smithy-client": "^3.1.9",
+            "@smithy/smithy-client": "^3.1.11",
             "@smithy/types": "^3.3.0",
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-retry": "^3.0.3",
@@ -29002,12 +29574,12 @@
           }
         },
         "@smithy/node-http-handler": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.3.tgz",
-          "integrity": "sha512-UiKZm8KHb/JeOPzHZtRUfyaRDO1KPKPpsd7iplhiwVGOeVdkiVJ5bVe7+NhWREMOKomrDIDdSZyglvMothLg0Q==",
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+          "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
           "requires": {
             "@smithy/abort-controller": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.4",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/querystring-builder": "^3.0.3",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
@@ -29023,9 +29595,9 @@
           }
         },
         "@smithy/protocol-http": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
-          "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
           "requires": {
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
@@ -29068,15 +29640,15 @@
           }
         },
         "@smithy/smithy-client": {
-          "version": "3.1.9",
-          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.9.tgz",
-          "integrity": "sha512-My2RaInZ4gSwJUPMaiLR/Nk82+c4LlvqpXA+n7lonGYgCZq23Tg+/xFhgmiejJ6XPElYJysTPyV90vKyp17+1g==",
+          "version": "3.1.11",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.11.tgz",
+          "integrity": "sha512-l0BpyYkciNyMaS+PnFFz4aO5sBcXvGLoJd7mX9xrMBIm2nIQBVvYgp2ZpPDMzwjKCavsXu06iuCm0F6ZJZc6yQ==",
           "requires": {
-            "@smithy/middleware-endpoint": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
             "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/protocol-http": "^4.0.4",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
-            "@smithy/util-stream": "^3.1.1",
+            "@smithy/util-stream": "^3.1.3",
             "tslib": "^2.6.2"
           }
         },
@@ -29145,12 +29717,12 @@
           }
         },
         "@smithy/util-stream": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.1.tgz",
-          "integrity": "sha512-EhRnVvl3AhoHAT2rGQ5o+oSDRM/BUSMPLZZdRJZLcNVUsFAjOs4vHaPdNQivTSzRcFxf5DA4gtO46WWU2zimaw==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+          "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
           "requires": {
-            "@smithy/fetch-http-handler": "^3.2.2",
-            "@smithy/node-http-handler": "^3.1.3",
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "@smithy/util-base64": "^3.0.0",
             "@smithy/util-buffer-from": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digiventures.stack/utils-helper",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "publishConfig": {
     "access": "public"
   },
@@ -19,7 +19,7 @@
     "@aws-sdk/client-cloudwatch": "^3.445.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.425.0",
     "@aws-sdk/client-s3": "^3.614.0",
-    "@aws-sdk/client-secrets-manager": "^3.614.0",
+    "@aws-sdk/client-secrets-manager": "^3.620.1",
     "@aws-sdk/client-sqs": "^3.614.0",
     "@aws-sdk/client-sts": "^3.614.0",
     "@elastic/elasticsearch": "7.9.0",

--- a/src/utils/RestUtils.ts
+++ b/src/utils/RestUtils.ts
@@ -64,12 +64,23 @@ export class RestUtils {
     }
 
     const regex = /(https:\/\/s3.amazonaws.com)(\/.*?\/)(.*)/;
-    const matchedUrl = document.match(regex);
-    if (!matchedUrl) {
-      throw new Error('Error match s3 utl');
+    const bucketInSubdomainRegex = /https:\/\/(.*)\.s3\.amazonaws\.com\/(.*)/;
+
+    let matchedUrl = document.match(bucketInSubdomainRegex);
+
+    let bucketName
+    let bucketKey
+    if (matchedUrl) {
+    bucketName = matchedUrl[1];
+    bucketKey = matchedUrl[2];
+  } else {
+      matchedUrl = document.match(regex);
+      if (!matchedUrl) {
+        throw new Error('Error match s3 url');
+      }
+      bucketName = matchedUrl[2].replace(/\//g, '');
+      bucketKey = matchedUrl[3];
     }
-    const bucketName = matchedUrl[2].replace(/\//g, '');
-    const bucketKey = matchedUrl[3];
     console.log('get from bucket and key', bucketName, bucketKey);
 
     const s3Helper: S3Helper = new S3Helper();

--- a/tests/utils/RestUtils.test.ts
+++ b/tests/utils/RestUtils.test.ts
@@ -1,4 +1,5 @@
 import { RestUtils } from '../../src';
+import { S3Helper } from '../../src/services/s3/S3Helper';
 import * as assert from 'assert';
 
 describe(__filename, () => {
@@ -8,21 +9,32 @@ describe(__filename, () => {
       restUtils = new RestUtils();
     });
   
+    beforeEach(() => {
+        jest.restoreAllMocks();
+      });
     test('should get a file from S3 and return it as a base64 string', async () => {
-      const document = 'https://s3.amazonaws.com/test.digiventures/5fd78a652ab79c000150e35b/IdCardFrontService/66a3e6d3b7b555c6bf3332aa-1722017571512'
-
-      const result = await restUtils.getBase64FileAsStringFromS3(document);
-  
-      console.log('Base64 Result:', result);
-      assert.ok(result);
+        const document = 'https://s3.amazonaws.com/test.digiventures/5fd78a652ab79c000150e35b/IdCardFrontService/66a3e6d3b7b555c6bf3332aa-1722017571512';
+    
+        const spy = jest.spyOn(S3Helper.prototype, 'getObject').mockResolvedValue(Buffer.from('test'));
+    
+        const result = await restUtils.getBase64FileAsStringFromS3(document);
+      
+        console.log('Base64 Result:', result);
+        assert.ok(result);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith('test.digiventures', '5fd78a652ab79c000150e35b/IdCardFrontService/66a3e6d3b7b555c6bf3332aa-1722017571512');
     });
 
     test('should get a file from faceid S3 bucket and return it as a base64 string', async () => {
-        const document = 'https://faceid-image-bucket-dev.s3.amazonaws.com/39910747/9b1190d9-ca6b-4d6b-ac48-4724b7a9d651.png';
+       const document = 'https://faceid-image-bucket-dev.s3.amazonaws.com/39910747/9b1190d9-ca6b-4d6b-ac48-4724b7a9d651.png';
+
+      const spy = jest.spyOn(S3Helper.prototype, 'getObject').mockResolvedValue(Buffer.from('test'));
       
-        const result = await restUtils.getBase64FileAsStringFromS3(document);
-    
-        console.log('Base64 Result:', result);
-        assert.ok(result);
-      });
+      const result = await restUtils.getBase64FileAsStringFromS3(document);
+      
+      console.log('Base64 Result:', result);
+      assert.ok(result);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith('faceid-image-bucket-dev', '39910747/9b1190d9-ca6b-4d6b-ac48-4724b7a9d651.png');
+    });
 });

--- a/tests/utils/RestUtils.test.ts
+++ b/tests/utils/RestUtils.test.ts
@@ -1,0 +1,28 @@
+import { RestUtils } from '../../src';
+import * as assert from 'assert';
+
+describe(__filename, () => {
+    let restUtils: RestUtils;
+
+    beforeAll(() => {
+      restUtils = new RestUtils();
+    });
+  
+    test('should get a file from S3 and return it as a base64 string', async () => {
+      const document = 'https://s3.amazonaws.com/test.digiventures/5fd78a652ab79c000150e35b/IdCardFrontService/66a3e6d3b7b555c6bf3332aa-1722017571512'
+
+      const result = await restUtils.getBase64FileAsStringFromS3(document);
+  
+      console.log('Base64 Result:', result);
+      assert.ok(result);
+    });
+
+    test('should get a file from faceid S3 bucket and return it as a base64 string', async () => {
+        const document = 'https://faceid-image-bucket-dev.s3.amazonaws.com/39910747/9b1190d9-ca6b-4d6b-ac48-4724b7a9d651.png';
+      
+        const result = await restUtils.getBase64FileAsStringFromS3(document);
+    
+        console.log('Base64 Result:', result);
+        assert.ok(result);
+      });
+});


### PR DESCRIPTION
Error al buscar imagen de faceid:
'Error: Error match s3 utl\n    at RestUtils.<anonymous> (/Users/eli-digi/Documents/digiventures/digiventures-global-mirror/packages/external-mirror-aws-lambda/node_modules/@digiventures.stack/utils-helper/src/utils/RestUtils.ts:69:13)'

Solución:
Agregar una regex que matchee la url de faceid.

Test:
RestUtils.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced URL handling for S3 by supporting both standard and subdomain formats, improving flexibility in processing various S3 URLs.

- **Bug Fixes**
	- Improved error handling for S3 URL matching, ensuring robust operations in the absence of valid URL formats.

- **Tests**
	- Introduced unit tests for the RestUtils class, increasing test coverage for S3 file retrieval and conversion functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->