### PR TITLE
🐛 FIX | Pasar secureOptions a basic-ftp para control de verificación TLS

### DIFF
--- a/src/client/ftp/FtpClientManager.ts
+++ b/src/client/ftp/FtpClientManager.ts
@@ -29,16 +29,21 @@ export class FtpClientManager implements IFtpClientManager {
 
   async connect(): Promise<any> {
     try {
+      const resolvedSecure =
+        this.options?.secure === undefined || this.options?.secure === null
+          ? 'implicit'
+          : typeof this.options.secure === 'string'
+          ? this.options.secure === 'true'
+          : Boolean(this.options.secure);
+
       let ftpOptions: AccessOptions = {
         host: this.options.host || process.env.SFTP_HOST,
         user: this.options.username || process.env.SFTP_USER,
         password: this.options.password || process.env.SFTP_PASS,
         port:
           this.options.port || parseInt(process.env.SFTP_PORT as string) || 22,
-        secure: this.options?.secure
-          ? this.options.secure === 'true'
-          : 'implicit',
-        secureOptions: this.options?.secureOptions,
+        secure: resolvedSecure,
+        secureOptions: resolvedSecure ? this.options?.secureOptions : undefined,
       };
 
       await this.client.access(ftpOptions);

--- a/src/client/ftp/FtpClientManager.ts
+++ b/src/client/ftp/FtpClientManager.ts
@@ -38,6 +38,7 @@ export class FtpClientManager implements IFtpClientManager {
         secure: this.options?.secure
           ? this.options.secure === 'true'
           : 'implicit',
+        secureOptions: this.options?.secureOptions,
       };
 
       await this.client.access(ftpOptions);


### PR DESCRIPTION
## Ticket

https://digiventures.atlassian.net/browse/OB-5265

## Description

**Problem:** `FtpClientManager.connect()` construye el objeto `AccessOptions` de `basic-ftp` manualmente sin incluir `secureOptions`. Esto impide pasar opciones TLS como `rejectUnauthorized: false`, necesario cuando el servidor SFTP usa un certificado de una CA no reconocida por Node.js.

**Why change:** El servidor SFTP de Fava (`ftp.favanet.com.ar`) usa un certificado que Node.js no puede verificar (`UNABLE_TO_VERIFY_LEAF_SIGNATURE`). La Lambda necesita conectarse con `secureOptions: { rejectUnauthorized: false }` para funcionar.

**Solution:** Agregar `secureOptions: this.options?.secureOptions` en el objeto `ftpOptions` que se pasa a `client.access()`. Si no se provee, el comportamiento es idéntico al actual (undefined = sin cambios en basic-ftp).

**Out of scope:** Cambios en la lógica de conexión, retry o upload.

## Evidence

CloudWatch log `/aws/lambda/FtpDocumentExportService`:
```
ERROR error connecting ftp client ftp.favanet.com.ar:21 UNABLE_TO_VERIFY_LEAF_SIGNATURE
```

## Checklist

- [ ] Manual testing done
- [x] Build passing (`npm run build` limpio)
- [x] Modified files reviewed
- [x] No console.logs or debug code

## Deploy Impact

- **Migrations:** No
- **New env vars:** No
- **Cross-team coordination:** Requiere actualizar el secret `sftp-fava-credentials-ApdSpn` en AWS Secrets Manager agregando `"secureOptions": { "rejectUnauthorized": false }`

## Merge Strategy

- [x] Squash
- [ ] Merge commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved FTP connection security handling: the app now normalizes secure option values and forwards additional secure connection options when a secure connection is used, enabling more reliable and configurable secure FTP connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->